### PR TITLE
docs: add nerves setup guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# Hello IoT Cloud

--- a/docs/nerves-getting-started-macos.md
+++ b/docs/nerves-getting-started-macos.md
@@ -1,0 +1,100 @@
+# Nerves の開発環境を構築 (MacOS)
+
+Nerves には、システム上にいくつかのプログラムが必要です。Erlang、Elixir、ファームウェアイメージをパッケージ化するためのツールなどがこれに含まれます。
+
+## Xcode コマンドライン ツールのインストール
+
+```bash
+xcode-select --install
+```
+
+## Homebrew のインストール
+
+まだ Homebrew のインストールをされていない方は以下のコマンドでインストールします。
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+`brew` コマンド を `$PATH` に追加します。
+
+```bash
+echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
+eval "$(/opt/homebrew/bin/brew shellenv)"
+```
+
+## 必要なパッケージのインストール
+
+```bash
+brew update
+
+# Erlang関連: see https://github.com/asdf-vm/asdf-erlang
+brew install wxwidgets libxslt fop openjdk
+
+# Nerves関連: see https://hexdocs.pm/nerves/installation.html
+brew install fwup squashfs coreutils xz pkg-config
+```
+
+## ASDF のインストール
+
+Nerves では、開発ホストで実行されている Erlang バージョンが組み込みターゲット（Raspberry Pi 4 等）の Erlang バージョンと互換性があることが求められます。そのため、十分な粒度でバージョンを管理できるよう ASDF を使用して Erlang と Elixir のインストールすることをお勧めします。
+
+```bash
+brew install asdf
+```
+
+`asdf.sh`スクリプトを`~/.zshrc`に追加します。詳細は[公式ドキュメント](https://asdf-vm.com/ja-jp/guide/getting-started.html)をご参照ください。
+
+```bash
+echo -e "\n. $(brew --prefix asdf)/libexec/asdf.sh" >> ${ZDOTDIR:-~}/.zshrc
+source ${ZDOTDIR:-~}/.zshrc
+```
+
+## Erlang と Elixir のインストール
+
+既に Homebrew を使用して Erlang と Elixir をインストールしている場合は、今から ASDF を用いてインストールするバージョンとの衝突を避けるために、それらを事前にアンインストールしておくことをお勧めします。
+
+```bash
+brew uninstall elixir
+brew uninstall erlang
+```
+
+Erlang と Elixir をインストールします。
+
+```bash
+asdf plugin-add erlang
+asdf plugin-add elixir
+
+asdf install erlang 27.0.1
+asdf install elixir 1.17.2-otp-27
+
+asdf global erlang 27.0.1
+asdf global elixir 1.17.2-otp-27
+```
+
+## Nerves 開発ツールのインストール
+
+nerves_bootstrap は、組み込みターゲットに適したクロスコンパイラを使用してコードが適切にコンパイルできる開発環境や新規 Nerves プロジェクト ジェネレーター（`mix nerves.new`コマンド） 提供します。
+
+```bash
+mix local.hex
+mix local.rebar
+
+mix archive.install hex nerves_bootstrap
+```
+
+## Nerves ファームウエアの開発
+
+Nerves ファームウエアの新規プロジェクトを生成する際に使用するコマンドは以下の通りです。
+
+```bash
+cd
+mix nerves.new hello_nerves
+cd hello_nerves
+export MIX_TARGET=rpi4
+mix deps.get
+mix firmware
+mix burn
+ssh nerves.local
+mix upload
+```

--- a/docs/nerves-getting-started-ubuntu-22.md
+++ b/docs/nerves-getting-started-ubuntu-22.md
@@ -1,0 +1,88 @@
+# Nerves の開発環境を構築 (Ubuntu 22.04 LTS)
+
+Nerves には、システム上にいくつかのプログラムが必要です。Erlang、Elixir、ファームウェアイメージをパッケージ化するためのツールなどがこれに含まれます。
+
+## 必要なパッケージのインストール
+
+```bash
+sudo apt update
+
+# Erlang関連: see https://github.com/asdf-vm/asdf-erlang
+sudo apt install build-essential autoconf m4 libncurses5-dev libwxgtk3.0-gtk3-dev libwxgtk-webview3.0-gtk3-dev libgl1-mesa-dev libglu1-mesa-dev libpng-dev libssh-dev unixodbc-dev xsltproc fop libxml2-utils libncurses-dev openjdk-11-jdk
+
+# Nerves関連: see https://hexdocs.pm/nerves/installation.html
+sudo apt install build-essential automake autoconf git squashfs-tools ssh-askpass pkg-config curl libmnl-dev
+```
+
+## fwup のインストール
+
+```bash
+cd
+curl -fLO https://github.com/fhunleth/fwup/releases/download/v1.10.2/fwup_1.10.2_amd64.deb
+sudo dpkg -i fwup_1.10.2_amd64.deb
+```
+
+## ASDF のインストール
+
+Nerves では、開発ホストで実行されている Erlang バージョンが組み込みターゲット（Raspberry Pi 4 等）の Erlang バージョンと互換性があることが求められます。そのため、十分な粒度でバージョンを管理できるよう ASDF を使用して Erlang と Elixir のインストールすることをお勧めします。
+
+```bash
+git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.14.1
+```
+
+`asdf.sh`スクリプトを`~/.bashrc`に追加します。詳細は[公式ドキュメント](https://asdf-vm.com/ja-jp/guide/getting-started.html)をご参照ください。
+
+```bash
+echo '. $HOME/.asdf/asdf.sh' >> ~/.bashrc
+echo '. $HOME/.asdf/completions/asdf.bash' >> ~/.bashrc
+source ~/.bashrc
+```
+
+## Erlang と Elixir のインストール
+
+既に apt を使用して Erlang と Elixir をインストールしている場合は、今から ASDF を用いてインストールするバージョンとの衝突を避けるために、それらを事前にアンインストールしておくことをお勧めします。
+
+```bash
+sudo apt remove elixir
+sudo apt remove erlang erlang-dev
+```
+
+Erlang と Elixir をインストールします。
+
+```bash
+asdf plugin-add erlang
+asdf plugin-add elixir
+
+asdf install erlang 27.0.1
+asdf install elixir 1.17.2-otp-27
+
+asdf global erlang 27.0.1
+asdf global elixir 1.17.2-otp-27
+```
+
+## Nerves 開発ツールのインストール
+
+nerves_bootstrap は、組み込みターゲットに適したクロスコンパイラを使用してコードが適切にコンパイルできる開発環境や新規 Nerves プロジェクト ジェネレーター（`mix nerves.new`コマンド） 提供します。
+
+```bash
+mix local.hex
+mix local.rebar
+
+mix archive.install hex nerves_bootstrap
+```
+
+## Nerves ファームウエアの開発
+
+Nerves ファームウエアの新規プロジェクトを生成する際に使用するコマンドは以下の通りです。
+
+```bash
+cd
+mix nerves.new hello_nerves
+cd hello_nerves
+export MIX_TARGET=rpi4
+mix deps.get
+mix firmware
+mix burn
+ssh nerves.local
+mix upload
+```

--- a/docs/nerves-getting-started-ubuntu-24.md
+++ b/docs/nerves-getting-started-ubuntu-24.md
@@ -1,0 +1,88 @@
+# Nerves の開発環境を構築 (Ubuntu 24.04 LTS)
+
+Nerves には、システム上にいくつかのプログラムが必要です。Erlang、Elixir、ファームウェアイメージをパッケージ化するためのツールなどがこれに含まれます。
+
+## 必要なパッケージのインストール
+
+```bash
+sudo apt update
+
+# Erlang関連: see https://github.com/asdf-vm/asdf-erlang
+sudo apt install build-essential autoconf m4 libncurses5-dev libwxgtk3.2-dev libwxgtk-webview3.2-dev libgl1-mesa-dev libglu1-mesa-dev libpng-dev libssh-dev unixodbc-dev xsltproc fop libxml2-utils libncurses-dev openjdk-11-jdk
+
+# Nerves関連: see https://hexdocs.pm/nerves/installation.html
+sudo apt install build-essential automake autoconf git squashfs-tools ssh-askpass pkg-config curl libmnl-dev
+```
+
+## fwup のインストール
+
+```bash
+cd
+curl -fLO https://github.com/fhunleth/fwup/releases/download/v1.10.2/fwup_1.10.2_amd64.deb
+sudo dpkg -i fwup_1.10.2_amd64.deb
+```
+
+## ASDF のインストール
+
+Nerves では、開発ホストで実行されている Erlang バージョンが組み込みターゲット（Raspberry Pi 4 等）の Erlang バージョンと互換性があることが求められます。そのため、十分な粒度でバージョンを管理できるよう ASDF を使用して Erlang と Elixir のインストールすることをお勧めします。
+
+```bash
+git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.14.1
+```
+
+`asdf.sh`スクリプトを`~/.bashrc`に追加します。詳細は[公式ドキュメント](https://asdf-vm.com/ja-jp/guide/getting-started.html)をご参照ください。
+
+```bash
+echo '. $HOME/.asdf/asdf.sh' >> ~/.bashrc
+echo '. $HOME/.asdf/completions/asdf.bash' >> ~/.bashrc
+source ~/.bashrc
+```
+
+## Erlang と Elixir のインストール
+
+既に apt を使用して Erlang と Elixir をインストールしている場合は、今から ASDF を用いてインストールするバージョンとの衝突を避けるために、それらを事前にアンインストールしておくことをお勧めします。
+
+```bash
+sudo apt remove elixir
+sudo apt remove erlang erlang-dev
+```
+
+Erlang と Elixir をインストールします。
+
+```bash
+asdf plugin-add erlang
+asdf plugin-add elixir
+
+asdf install erlang 27.0.1
+asdf install elixir 1.17.2-otp-27
+
+asdf global erlang 27.0.1
+asdf global elixir 1.17.2-otp-27
+```
+
+## Nerves 開発ツールのインストール
+
+nerves_bootstrap は、組み込みターゲットに適したクロスコンパイラを使用してコードが適切にコンパイルできる開発環境や新規 Nerves プロジェクト ジェネレーター（`mix nerves.new`コマンド） 提供します。
+
+```bash
+mix local.hex
+mix local.rebar
+
+mix archive.install hex nerves_bootstrap
+```
+
+## Nerves ファームウエアの開発
+
+Nerves ファームウエアの新規プロジェクトを生成する際に使用するコマンドは以下の通りです。
+
+```bash
+cd
+mix nerves.new hello_nerves
+cd hello_nerves
+export MIX_TARGET=rpi4
+mix deps.get
+mix firmware
+mix burn
+ssh nerves.local
+mix upload
+```


### PR DESCRIPTION
### 概要

Nerves の開発環境を構築 の資料をマークダウンとしてまとめる。ホストマシンのOSにより内容が異なるため、 別々のファイルで管理する。基本的内容は既存のものを踏襲。簡潔な補足事項を追記。

Ubuntuはバージョンによりインストールするパッケージが異なるので要注意。

![hello-iot-cloud-docs-2024-08-27 11-55](https://github.com/user-attachments/assets/b745444e-b4fd-4f84-b3ec-70689219af5b)

### 資料

- https://github.com/asdf-vm/asdf-erlang
- https://hexdocs.pm/nerves/installation.html
- https://asdf-vm.com/ja-jp/guide/getting-started.html
- https://github.com/fwup-home/fwup/releases
- https://github.com/erlang/otp/releases
- https://github.com/elixir-lang/elixir/releases/
- https://wiki.ubuntu.com/Releases

### 動作確認

ubuntu はdocker でmix firmware まで。

- [x] ubuntu 22 (docker)
- [x] ubuntu 24 (docker)
- [x] macos

### Notes

- 依存パッケージが色んな理由でインストールされているので、管理がしやすいように分離。例えば、Nervesから求められるものもあれば、Erlangのインストールに必要なものも有ります。
- fwup のダウンロードに使うプログラムをwget から curl に変更。理由は、単純にNervesが curl を使っているからです。インストールするプログラムを一個減らせます。
- README.md にプロジェクト名だけ書いておきました。

